### PR TITLE
Option to make concurrent only for function calls with equal arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = function (fn, opts) {
     }
     try {
       cacheToUse.count += 1
-      console.log(cacheToUse)
       if (cacheToUse.count > concurrency) {
         await new Promise((resolve) => cacheToUse.queue.push({ resolve }))
       }

--- a/test/index.js
+++ b/test/index.js
@@ -96,3 +96,23 @@ test('check error throwing', async (t) => {
 
   t.end()
 })
+
+test('concurrency is 1 and byArguments', async (t) => {
+  let total = 0
+  const fn = makeConcurrent((x) => {
+    total += x
+    return wait(100)
+  }, { byArguments: true })
+
+  fn(2)
+  fn(4)
+  fn(4)
+
+  await wait(10)
+  t.equal(total, 2 + 4)
+
+  await wait(100)
+  t.equal(total, 10)
+
+  t.end()
+})


### PR DESCRIPTION
Possible usage: 
I have a function that make request to server and caches results.
If two functions called one by one, i would like to make only one request wait for result and set cache. Second function call will be executed only after first one finished and return cache.

On the other side i don't want to wait if function request params changed