### PR TITLE
Add .byArguments() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Anywhere where you need limited access to some resource.
 
 When we call function created by `make-concurrent` counter of called functions increased by `1`, then increased counter compared with `concurrency` option, if counter is greater than `concurrency` then we create `Promise`, push `resolve` function to queue ([FIFO](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics))) and wait while this `Promise` will be resolved, before call original function. When execution of original function will be finished we decrease counter on `1` and check queue, if queue length is not zero we take first item and call it, which resolve `Promise` and original function will be called again.
 
-All code is less than 30 lines, just [check it](index.js). This will take 2 minutes, but will give better understanding how `make-concurrent` works and how can be used effectively.
+All code is less than 50 lines, just [check it](index.js). This will take 2 minutes, but will give better understanding how `make-concurrent` works and how can be used effectively.
 
 ## Examples
 
-#### Limited acces by API key
+#### Limited access by API key
 
 Assume you need make requests to some API, but this API have limit of simultaneous requests by API key.
 
@@ -86,7 +86,7 @@ const safeUpdate = makeConcurrent(unsafeChange)
 // safeUpdate('alice')
 ```
 
-While `safeUpdate` going to be safe function for working with `state`, it's good as general approach. But here state changed for specified user, so we can optimize it:
+While `safeUpdate` going to be safe function for working with `state`, it's good as general approach. But here state changed for specified user, so we can use the `.byArguments()` method:
 
 ```js
 const makeConcurrent = require('make-concurrent')
@@ -98,12 +98,7 @@ async function unsafeUpdate (user) {
   state[user] = newValue
 }
 
-const fns = {}
-async function safeUpdate (user) {
-  if (!fns[user]) fns[user] = makeConcurrent(unsafeChange)
-  return fns[user](user)
-}
-
+const safeUpdate = makeConcurrent.byArguments(unsafeUpdate)
 // safeUpdate('alice')
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
-function makeConcurrent (fn: Function, { concurrency }?: {
+declare function makeConcurrent (fn: Function, { concurrency }?: {
     concurrency?: number;
 }): (...args: any[]) => Promise<any>;
-declare namespace makeConcurrent {}
+declare namespace makeConcurrent {
+  function byArguments(fn: Function, createKey?: Function): (...args: any[]) => Promise<any>;
+}
 export = makeConcurrent;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function (fn, { concurrency = 1 } = {}) {
+function makeConcurrent (fn, { concurrency = 1 } = {}) {
   validateConcurrencyValue(concurrency)
 
   let count = 0
@@ -20,7 +20,26 @@ module.exports = function (fn, { concurrency = 1 } = {}) {
   }
 }
 
+module.exports = makeConcurrent
+
 function validateConcurrencyValue (value) {
   const isValid = typeof value === 'number' && value > 0 && (value === Infinity || value % 1 === 0)
   if (!isValid) throw new TypeError(`Invalid concurrency value: ${value}`)
+}
+
+module.exports.byArguments = function makeConcurrentByArguments (fn, createKey = JSON.stringify) {
+  const keys = new Map()
+  return async (...args) => {
+    const key = createKey(args)
+    if (!keys.has(key)) keys.set(key, { count: 0, fn: makeConcurrent(fn) })
+
+    const state = keys.get(key)
+    try {
+      state.count++
+      return await state.fn(...args)
+    } finally {
+      state.count--
+      if (state.count === 0) keys.delete(key)
+    }
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -97,7 +97,7 @@ test('check error throwing', async (t) => {
   t.end()
 })
 
-test('.byArguments() > should call function concurrently when arguments are equal', async (t) => {
+test('.byArguments() > should limit concurrency when arguments are equal', async (t) => {
   let total = 0
   const fn = makeConcurrent.byArguments((x) => {
     total += x

--- a/test/index.js
+++ b/test/index.js
@@ -96,3 +96,24 @@ test('check error throwing', async (t) => {
 
   t.end()
 })
+
+test('.byArguments() > should call function concurrently when arguments are equal', async (t) => {
+  let total = 0
+  const fn = makeConcurrent.byArguments((x) => {
+    total += x
+    return wait(100)
+  })
+
+  fn(2)
+  fn(4)
+  fn(4)
+
+  await wait(10)
+  // fn(2) and fn(4) runs at the same time
+  t.equal(total, 6)
+
+  await wait(100)
+  // second fn(4) runs only after first fn(4) call completed
+  t.equal(total, 10)
+  t.end()
+})


### PR DESCRIPTION
@fanatid This additional wrapper utility was something you wrote back at @ExodusMovement, which we're still using today. Since we use it in multiple projects, we thought it might be useful to make it part of `make-concurrent` itself. Let me know your thoughts and if any additional changes are needed.